### PR TITLE
Persist comment accessed status in Redis via cmds

### DIFF
--- a/Frontend/static/nuxt_static_viewer/r2/controller/controller_cmds.js
+++ b/Frontend/static/nuxt_static_viewer/r2/controller/controller_cmds.js
@@ -175,6 +175,9 @@
                     case 'DeleteComment':
                         success = deleteComment(doc, cmd);
                         break;
+                    case 'FlagAccessedComment':
+                        success = true;     //Dont process here. The cmd will be handled in r2.commentHistory.consumeCmd()
+                        break;
                     default:
                         console.error('Unknown Cmd Error:', JSON.stringify(cmd));
                 }
@@ -750,6 +753,9 @@
             }
             return false;
         };
+
+        
+        
 
         return pub;
     }());

--- a/Frontend/static/nuxt_static_viewer/r2/controller/edu_controller_dbs.js
+++ b/Frontend/static/nuxt_static_viewer/r2/controller/edu_controller_dbs.js
@@ -143,7 +143,8 @@ const r2Sync = (function() {
               if (!(cmds[i].user + '_' + cmds[i].time in my_cmds)) {
                 if (r2.cmd.executeCmd(r2App.doc, cmds[i], false)) {
                   r2.commentHistory.consumeCmd(cmds[i])
-                } else {
+                } 
+                else {
                   console.error(
                     'Skipped an invalid cmd : ' + JSON.stringify(cmds[i])
                   )
@@ -203,7 +204,7 @@ const r2Sync = (function() {
         q.push(upload_audio_cmd)
       }
       q.push(cmd)
-      r2.commentHistory.consumeCmd(cmd)
+      r2.commentHistory.consumeCmd(cmd)                            //Pushing commenthistory cmd also consumes it
     }
 
     const uploadCmd = function(cmd) {

--- a/Frontend/static/nuxt_static_viewer/r2/model/doc_model.js
+++ b/Frontend/static/nuxt_static_viewer/r2/model/doc_model.js
@@ -2736,7 +2736,7 @@
     };
 
     /**
-     * Calc spotlight width for a particular piece.
+     * Calc spotlight width
      */
     r2.Spotlight.calcWidth = function(piece) {
         let computedWidth = 0.0;


### PR DESCRIPTION
- [x] Persist comment status as new or accessed with a cmd that is consumed to update UI
 